### PR TITLE
[monitor] Document backlog seeder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ See `AGENTS.md` and `MONITOR.md` to get started.
 - Review the [diagnosis](DIAGNOSIS.md).
 - Follow the [remediation plan](FIX_PLAN.md).
 - Configure the remote using [push instructions](PUSH_INSTRUCTIONS.md).
+
+## Backlog seeder
+
+Use the backlog seeder to create or update GitHub issues from the WBS.
+
+- **Dry-run** (default): prints the actions it would take without touching GitHub.
+- **Apply**: pass `--apply` or trigger the workflow with `apply: true` to create/update issues for real.
+
+Required environment variables:
+
+- `GITHUB_TOKEN` – token with permission to create issues
+- `GITHUB_REPOSITORY` – repository in `owner/name` format
+
+See [`.github/workflows/seed_backlog.yml`](.github/workflows/seed_backlog.yml) for the automation workflow.


### PR DESCRIPTION
## Summary
- document backlog seeder usage in the README, covering dry-run vs apply, required environment variables, and the workflow link

## Testing
- `python -m pytest agents/monitor/tests -q`
- `ruff check . && ruff format --check .`
- `python agents/monitor/monitor.py --dry-run | head -n 20` *(before)*
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREY**

## WP2
- **WP2-T2.1** Derive initial target panel & design hypotheses — due 2025-09-10 — GAR: **GREY**

## WP3
- **WP3-T3.1** In-vitro assay pipeline established — due 2025-11-01 — GAR: **GREY**
```
- `python agents/monitor/monitor.py --dry-run | head -n 20` *(after)*
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREY**

## WP2
- **WP2-T2.1** Derive initial target panel & design hypotheses — due 2025-09-10 — GAR: **GREY**

## WP3
- **WP3-T3.1** In-vitro assay pipeline established — due 2025-11-01 — GAR: **GREY**
```

No related issues.

------
https://chatgpt.com/codex/tasks/task_e_68a5c0a7e9f4832e88c791e2ddf54385