### PR TITLE
[monitor] add compliance scoring and risk rules

### DIFF
--- a/MONITOR.md
+++ b/MONITOR.md
@@ -8,3 +8,14 @@ Monitor A tracks the Xylella project end-to-end by knowing the full work breakdo
 - Daily: Action runs; GAR summary posted; alerts for <14-day deadlines.
 - Weekly: PM reviews monitor report; updates owners.yaml; resolves blockers.
 - Per Milestone: Gate checks; evidence binder updated.
+
+## Rule semantics
+
+### Compliance rules
+- **deadline** – items past their due date reduce the compliance score.
+- **evidence** – missing acceptance evidence reduces the compliance score.
+The overall compliance score is the percentage of rule weights satisfied across all WBS items (0–100).
+
+### Risk rules
+- **due_soon** (medium) – item due within 7 days.
+- **overdue_high** (high) – item overdue by more than 30 days.

--- a/agents/monitor/monitor.py
+++ b/agents/monitor/monitor.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import pathlib
 import sys
-from datetime import datetime
+from datetime import date, datetime
 
 import yaml
 from github import Github  # third-party
@@ -15,9 +15,12 @@ def load_yaml(p):
         return yaml.safe_load(f)
 
 
-def gar_for_due(due_str):
+def gar_for_due(due_val):
     try:
-        due = datetime.strptime(due_str, "%Y-%m-%d").date()
+        if isinstance(due_val, date):
+            due = due_val
+        else:
+            due = datetime.strptime(str(due_val), "%Y-%m-%d").date()
     except Exception:
         return "grey"
     today = datetime.utcnow().date()
@@ -28,19 +31,80 @@ def gar_for_due(due_str):
     return "green"
 
 
+def evaluate_risk(item, rules, today=None):
+    today = today or datetime.utcnow().date()
+    try:
+        val = item.get("due", "")
+        if isinstance(val, date):
+            due = val
+        else:
+            due = datetime.strptime(str(val), "%Y-%m-%d").date()
+    except Exception:
+        return None
+    delta = (due - today).days
+    for rule in (rules or {}).values():
+        if "days_overdue" in rule and delta < -int(rule.get("days_overdue", 0)):
+            return rule.get("severity")
+        if "days_until_due" in rule and 0 <= delta <= int(
+            rule.get("days_until_due", 0)
+        ):
+            return rule.get("severity")
+    return None
+
+
+def evaluate_compliance(items, rules, today=None):
+    today = today or datetime.utcnow().date()
+    total = 0.0
+    passed = 0.0
+    for it in items:
+        try:
+            val = it.get("due", "")
+            if isinstance(val, date):
+                due = val
+            else:
+                due = datetime.strptime(str(val), "%Y-%m-%d").date()
+        except Exception:
+            due = None
+        r = (rules or {}).get("deadline", {})
+        w = float(r.get("weight", 1))
+        total += w
+        if due and due >= today:
+            passed += w
+        r = (rules or {}).get("evidence", {})
+        w = float(r.get("weight", 1))
+        total += w
+        if it.get("acceptance"):
+            passed += w
+    if total == 0:
+        return 100
+    return int(round(100 * passed / total))
+
+
 def render_summary():
     w = load_yaml(ROOT / "wbs" / "wbs.yaml") or {}
+    compliance_rules = (
+        load_yaml(ROOT / "agents" / "monitor" / "rules" / "compliance_rules.yaml") or {}
+    )
+    risk_rules = (
+        load_yaml(ROOT / "agents" / "monitor" / "rules" / "risk_rules.yaml") or {}
+    )
     lines = ["# Monitor A — GAR Summary", ""]
+    all_items = []
     for wp, items in (w.get("wbs") or {}).items():
         lines.append(f"## {wp}")
         for it in items:
+            all_items.append(it)
             due = it.get("due", "?")
             gar = gar_for_due(due)
+            risk = evaluate_risk(it, risk_rules)
+            risk_str = f" — RISK: {risk.upper()}" if risk else ""
             lines.append(
-                f"- **{it.get('id', '?')}** {it.get('title', '')} — due {due} — GAR: **{gar.upper()}**"
+                f"- **{it.get('id', '?')}** {it.get('title', '')} — due {due} — GAR: **{gar.upper()}**{risk_str}"
             )
         lines.append("")
-    return "\n".join(lines)
+    score = evaluate_compliance(all_items, compliance_rules)
+    lines.append(f"Compliance score: {score}")
+    return "\n".join(lines), score
 
 
 def post_comment_to_latest_pr(body: str) -> int:
@@ -71,11 +135,13 @@ def main(argv=None):
         "--emit-status", action="store_true", help="Alias of --dry-run for CI"
     )
     parser.add_argument(
-        "--post-comments", action="store_true", help="Post GAR to the latest open PR"
+        "--post-comments",
+        action="store_true",
+        help="Post GAR to the latest open PR",
     )
     args = parser.parse_args(argv)
 
-    summary = render_summary()
+    summary, _score = render_summary()
     print(summary)
 
     if args.post_comments:

--- a/agents/monitor/rules/compliance_rules.yaml
+++ b/agents/monitor/rules/compliance_rules.yaml
@@ -1,0 +1,6 @@
+deadline:
+  description: Items past due reduce compliance
+  weight: 0.5
+evidence:
+  description: Items must include acceptance evidence
+  weight: 0.5

--- a/agents/monitor/rules/risk_rules.yaml
+++ b/agents/monitor/rules/risk_rules.yaml
@@ -1,0 +1,8 @@
+due_soon:
+  description: Item due within 7 days triggers medium risk
+  days_until_due: 7
+  severity: medium
+overdue_high:
+  description: Item overdue by more than 30 days triggers high risk
+  days_overdue: 30
+  severity: high

--- a/agents/monitor/tests/test_monitor.py
+++ b/agents/monitor/tests/test_monitor.py
@@ -1,0 +1,37 @@
+from datetime import date, timedelta
+
+from agents.monitor import monitor
+
+
+def test_compliance_and_risk():
+    today = date(2024, 1, 1)
+    items = [
+        {
+            "id": "good",
+            "due": (today + timedelta(days=30)).strftime("%Y-%m-%d"),
+            "acceptance": ["doc"],
+        },
+        {
+            "id": "overdue",
+            "due": (today - timedelta(days=40)).strftime("%Y-%m-%d"),
+            "acceptance": [],
+        },
+        {
+            "id": "soon",
+            "due": (today + timedelta(days=3)).strftime("%Y-%m-%d"),
+            "acceptance": ["x"],
+        },
+    ]
+    compliance_rules = monitor.load_yaml(
+        monitor.ROOT / "agents" / "monitor" / "rules" / "compliance_rules.yaml"
+    )
+    risk_rules = monitor.load_yaml(
+        monitor.ROOT / "agents" / "monitor" / "rules" / "risk_rules.yaml"
+    )
+
+    score = monitor.evaluate_compliance(items, compliance_rules, today)
+    assert score == 67
+
+    assert monitor.evaluate_risk(items[0], risk_rules, today) is None
+    assert monitor.evaluate_risk(items[1], risk_rules, today) == "high"
+    assert monitor.evaluate_risk(items[2], risk_rules, today) == "medium"


### PR DESCRIPTION
## Summary
- define deadline/evidence compliance rules and risk triggers
- compute compliance_score from rules and show risk tags
- document rule semantics

## Testing
- `python -m pytest agents/monitor/tests -q`
- `ruff check .`
- `ruff format --check .`
- `python agents/monitor/monitor.py --dry-run | head -n 20`

## Before
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREY**
```

## After
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREEN**
...
Compliance score: 67
```

## Related Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a5c30c0fc8832e99c7ffc9634e9088