### PR TITLE
[monitor] describe dashboard without bundled screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ See `AGENTS.md` and `MONITOR.md` to get started.
 - Review the [diagnosis](DIAGNOSIS.md).
 - Follow the [remediation plan](FIX_PLAN.md).
 - Configure the remote using [push instructions](PUSH_INSTRUCTIONS.md).
+
+## Dashboard
+
+The monitoring dashboard summarizes each work package in a table showing
+GAR flags, upcoming 14-day deadlines, and any current blockers. Run
+`python agents/monitor/monitor.py --dry-run` to generate the dashboard
+locally.


### PR DESCRIPTION
## Summary
- Replace bundled dashboard screenshot with a textual description in the README so the repository no longer stores a binary image.

## Testing
- `ruff check .`
- `ruff format --check .`
- `python -m pytest agents/monitor/tests -q`
- `python agents/monitor/monitor.py --dry-run`

## Monitor Output
Before (compliance_score: 100):
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREY**

## WP2
- **WP2-T2.1** Derive initial target panel & design hypotheses — due 2025-09-10 — GAR: **GREY**

## WP3
- **WP3-T3.1** In-vitro assay pipeline established — due 2025-11-01 — GAR: **GREY**
```
After (compliance_score: 100):
```
# Monitor A — GAR Summary

## WP1
- **WP1-D1.1** Project handbook & quality plan — due 2025-10-15 — GAR: **GREY**

## WP2
- **WP2-T2.1** Derive initial target panel & design hypotheses — due 2025-09-10 — GAR: **GREY**

## WP3
- **WP3-T3.1** In-vitro assay pipeline established — due 2025-11-01 — GAR: **GREY**
```

Related issues: none

------
https://chatgpt.com/codex/tasks/task_e_68a5c80d1128832e9853d1917a75a2ec