### PR TITLE
chore: outline agent orchestration tasks for jules

### DIFF
--- a/tasks/jules_task_autogen_01.md
+++ b/tasks/jules_task_autogen_01.md
@@ -1,0 +1,27 @@
+**Assigned To:** Jules AI
+**Task ID:** JULES-AUTOGEN-01
+**Title:** Implement AgentTask Model and TaskStatus Enum
+
+**Objective:**
+Create the SQLAlchemy model and enumeration needed to persist and track agent task execution.
+
+**Detailed Instructions:**
+1.  Create a new file at `eufm/app/models/agent_task.py`.
+2.  Define an `Enum` named `TaskStatus` with members: `QUEUED`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`.
+3.  Define a model class `AgentTask` inheriting from the project's base SQLAlchemy model (`db.Model` or `BaseModel`). Include columns:
+    *   `id` (UUID primary key)
+    *   `agent_type` (string)
+    *   `parameters` (JSON)
+    *   `result` (JSON, nullable)
+    *   `status` (`TaskStatus`)
+    *   `priority` (string, default `'normal'`)
+    *   `error` (text, nullable)
+    *   `created_at` and `updated_at` timestamps
+4.  Implement a `save(self) -> None` method that commits the record and a `to_dict(self) -> dict` helper for serialization.
+5.  Update `eufm/app/models/__init__.py` to export `AgentTask` and `TaskStatus`.
+
+**Context:**
+All models reside under `eufm/app/models`. The application uses Flask and SQLAlchemy; follow existing patterns for session management.
+
+**Deliverable:**
+Submit your work as a single Pull Request against the `main` branch including the new model file and updated package exports.

--- a/tasks/jules_task_autogen_02.md
+++ b/tasks/jules_task_autogen_02.md
@@ -1,0 +1,22 @@
+**Assigned To:** Jules AI
+**Task ID:** JULES-AUTOGEN-02
+**Title:** Build Asynchronous TaskQueue Utility
+
+**Objective:**
+Provide a priority-aware queue to manage pending agent tasks before execution.
+
+**Detailed Instructions:**
+1.  Create a new file at `eufm/app/utils/task_queue.py`.
+2.  Implement a `TaskQueue` class using `asyncio.PriorityQueue`.
+    *   Method `__init__(self)` should initialize an internal `PriorityQueue`.
+    *   Method `async enqueue(self, task_id: str, priority: str)` should map priority strings (`'high'`, `'normal'`, `'low'`) to numerical values and put `(priority_value, task_id)` into the queue.
+    *   Method `async dequeue(self) -> Optional[str]` should return the next `task_id` or `None` if the queue is empty.
+    *   Method `size(self) -> int` should return the current queue size.
+3.  Include docstrings and type hints for all methods.
+4.  Update `eufm/app/utils/__init__.py` to export `TaskQueue`.
+
+**Context:**
+Utilities live under `eufm/app/utils`. This queue will be consumed by the upcoming `AgentOrchestrator` service.
+
+**Deliverable:**
+Submit your work as a single Pull Request against the `main` branch including the new utility module and package export.

--- a/tasks/jules_task_autogen_03.md
+++ b/tasks/jules_task_autogen_03.md
@@ -1,0 +1,35 @@
+**Assigned To:** Jules AI
+**Task ID:** JULES-AUTOGEN-03
+**Title:** Implement AgentOrchestrator Service
+
+**Objective:**
+Create the service that schedules, executes, and tracks agent tasks using the TaskQueue and AgentTask model.
+
+**Detailed Instructions:**
+1.  Create `eufm/app/services/agent_orchestrator.py`.
+2.  Define class `AgentOrchestrator` with constructor `__init__(self, ai_manager, max_concurrent_tasks: int = 5)` that sets up:
+    *   an `AgentFactory` instance
+    *   a `TaskQueue` instance
+    *   a dictionary `active_tasks: Dict[str, asyncio.Task]`
+    *   a `ThreadPoolExecutor` limited by `max_concurrent_tasks`
+3.  Implement method `async create_task(self, agent_type: str, parameters: Dict[str, Any], priority: str = 'normal') -> AgentTask`:
+    *   create and persist an `AgentTask` with `status=TaskStatus.QUEUED`
+    *   enqueue the task ID via `TaskQueue`
+    *   trigger `_process_queue`
+4.  Implement private method `async _process_queue(self)` to launch queued tasks while concurrency allows.
+5.  Implement private method `async _execute_task(self, task_id: str)` to:
+    *   load `AgentTask` from the database
+    *   update status to `RUNNING`
+    *   create agent via `AgentFactory` and call `await agent.run(task.parameters)`
+    *   store result and mark status `COMPLETED`, or on exception record `FAILED` and `error`
+    *   remove task from `active_tasks` and continue processing the queue
+6.  Implement `get_task_status(self, task_id: str) -> Optional[AgentTask]`.
+7.  Implement `async cancel_task(self, task_id: str) -> bool` to cancel active or queued tasks.
+8.  Implement `get_system_status(self) -> Dict[str, Any]` returning counts of active tasks, queue size, remaining capacity, and available agent types.
+9.  Ensure appropriate logging statements for task lifecycle events.
+
+**Context:**
+Service modules live in `eufm/app/services`. This orchestrator will be called from Flask endpoints and must be fully asynchronous.
+
+**Deliverable:**
+Submit your work as a single Pull Request against `main` including the new service module.

--- a/tasks/jules_task_autogen_04.md
+++ b/tasks/jules_task_autogen_04.md
@@ -1,0 +1,23 @@
+**Assigned To:** Jules AI
+**Task ID:** JULES-AUTOGEN-04
+**Title:** Expose Agent Task Management API Endpoints
+
+**Objective:**
+Provide REST endpoints that allow clients to create, monitor, cancel, and inspect agent tasks through the AgentOrchestrator.
+
+**Detailed Instructions:**
+1.  Create `eufm/app/api/agent_tasks.py` defining a Flask `Blueprint` named `agent_tasks_bp`.
+2.  Implement the following routes:
+    *   `POST /agent-tasks` → parse JSON for `agent_type`, `parameters`, optional `priority`; call `await app.agent_orchestrator.create_task(...)`; return `{"task_id": <id>}`.
+    *   `GET /agent-tasks/<task_id>` → return serialized task status from `get_task_status`.
+    *   `POST /agent-tasks/<task_id>/cancel` → invoke `cancel_task`; return success flag.
+    *   `GET /agent-tasks/system-status` → return `get_system_status` dictionary.
+3.  Since Flask view functions are synchronous, wrap orchestrator calls with `asyncio.run` or use `async` views if the project uses `Quart` or Flask async support.
+4.  Register the blueprint in `eufm/app/__init__.py` after app creation (e.g., `app.register_blueprint(agent_tasks_bp, url_prefix="/api")`).
+5.  Document each endpoint with docstrings explaining request and response structures.
+
+**Context:**
+API modules live under `eufm/app/api`. The orchestrator instance should be accessible via `app.agent_orchestrator` or similar initialization in `create_app`.
+
+**Deliverable:**
+Submit your work as a single Pull Request against `main` including the new API module and the updated application factory.


### PR DESCRIPTION
## Summary
- break down Agent Orchestration and Task Management plan into concrete tasks for Jules
- add tasks for AgentTask model, TaskQueue utility, orchestrator service, and API endpoints

## Testing
- `ruff check . && ruff format --check .` *(fails: F541 f-string without any placeholders, F401 unused imports, etc.)*
- `python -m pytest agents/monitor/tests -q` *(fails: file or directory not found)*
- `python agents/monitor/monitor.py --dry-run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bdb5ed60832eb8e6dad188b7105b