### PR TITLE
feat(router): integrate SmartTaskRouter + CLI + tests

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -14,5 +14,9 @@
 - `2025-09-01 00:12:08`: Merged all successful branches from the overnight initiative into the main branch.
 - `YYYY-MM-DD HH:MM:SS`: Initializing the project journal.
 
+## Router POC integrated
+- Added automatic agent routing via SmartTaskRouter.
+- Introduced CLI usage with `python -m scripts.route "prompt"` to inspect routing decisions.
+
 ## Open Questions & Blockers
 - None at this time.

--- a/app/api/route_task.py
+++ b/app/api/route_task.py
@@ -1,0 +1,5 @@
+from app.services.task_router import route_task as _route
+
+
+def route_task(prompt: str) -> tuple[str, str]:
+    return _route(prompt)

--- a/app/services/agent_factory.py
+++ b/app/services/agent_factory.py
@@ -5,6 +5,7 @@ from app.agents.document_agent import DocumentAgent
 from app.agents.proposal_agent import ProposalAgent
 from app.agents.coordinator_agent import CoordinatorAgent
 from app.utils.ai_services import AIServices
+from app.services.task_router import route_task, log_routing_decision
 
 class AgentFactory:
     """Factory for creating and configuring AI agents."""
@@ -21,6 +22,14 @@ class AgentFactory:
 
     def create_agent(self, agent_type: str, agent_id: str, agent_config: Dict[str, Any] = None) -> BaseAgent:
         """Create an agent instance of the specified type."""
+
+        if agent_type == "auto":
+            if not agent_config or "prompt" not in agent_config:
+                raise ValueError("Auto agent requires 'prompt' in agent_config")
+            prompt = agent_config.pop("prompt")
+            agent_type, reason = route_task(prompt)
+            log_routing_decision(prompt, agent_type, reason)
+
         agent_class = self._agent_registry.get(agent_type)
         if not agent_class:
             raise ValueError(f"Unknown agent type: {agent_type}")

--- a/app/services/task_router.py
+++ b/app/services/task_router.py
@@ -5,14 +5,23 @@ which agent in the task force should handle a user's request.
 """
 
 from typing import Iterable
+import hashlib
+import json
+from uuid import uuid4
+from datetime import datetime
+
+from config.logging import get_logger
 
 
-# Mapping of agent names to keywords that should trigger them.
+logger = get_logger(__name__)
+
+
+# Mapping of agent keys to keywords that should trigger them.
 _ROUTING_TABLE = {
-    "Perplexity Sonar": {"research", "find", "analyze", "summarize"},
-    "OpenAI Codex": {"code", "implement", "refactor", "script"},
-    "Claude Code": {"strategy", "review", "plan", "supervise"},
-    "Gemini CLI": {"system", "operations", "execute", "run"},
+    "research": {"research", "find", "analyze", "summarize"},
+    "document": {"document", "write", "draft", "edit"},
+    "proposal": {"proposal", "strategy", "plan", "review"},
+    "coordinator": {"coordinate", "system", "execute", "run"},
 }
 
 
@@ -26,19 +35,35 @@ def _contains_keyword(prompt: str, keywords: Iterable[str]) -> bool:
     return any(keyword in prompt_lower for keyword in keywords)
 
 
-def route_task(prompt: str) -> str:
+def route_task(prompt: str) -> tuple[str, str]:
     """Suggest the most suitable agent for the given prompt.
 
     Args:
         prompt: The user's task description.
 
     Returns:
-        The name of the recommended agent.
+        Tuple of the recommended agent key and the routing reason.
     """
 
+    prompt_lower = prompt.lower()
     for agent, keywords in _ROUTING_TABLE.items():
-        if _contains_keyword(prompt, keywords):
-            return agent
+        matched = [kw for kw in keywords if kw in prompt_lower]
+        if matched:
+            return agent, f"Matched keywords: {', '.join(matched)}"
 
     # Fallback agent if nothing matches.
-    return "OpenAI Codex"
+    return "document", "No keywords matched; using default"
+
+
+def log_routing_decision(prompt: str, chosen_agent: str, reason: str) -> dict:
+    """Log a routing decision and return the record."""
+
+    record = {
+        "run_id": str(uuid4()),
+        "prompt_hash": hashlib.sha1(prompt.encode("utf-8")).hexdigest(),
+        "chosen_agent": chosen_agent,
+        "reason": reason,
+        "ts": datetime.utcnow().isoformat(),
+    }
+    logger.info(json.dumps(record))
+    return record

--- a/scripts/route.py
+++ b/scripts/route.py
@@ -1,0 +1,20 @@
+import json
+import sys
+
+from config.logging import setup_logging
+from app.api.route_task import route_task
+from app.services.task_router import log_routing_decision
+
+
+def main(prompt: str) -> None:
+    setup_logging()
+    agent, reason = route_task(prompt)
+    record = log_routing_decision(prompt, agent, reason)
+    print(json.dumps(record))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m scripts.route \"prompt\"")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/tests/test_agent_factory_auto.py
+++ b/tests/test_agent_factory_auto.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.agent_factory import AgentFactory
+from app.utils.ai_services import AIServices
+from app.agents.research_agent import ResearchAgent
+
+
+def test_agent_factory_auto_selects_research():
+    factory = AgentFactory(ai_services=AIServices(settings={}), base_config={})
+    agent = factory.create_agent("auto", "agent-1", {"prompt": "research climate"})
+    assert isinstance(agent, ResearchAgent)

--- a/tests/test_route_cli.py
+++ b/tests/test_route_cli.py
@@ -1,0 +1,19 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_route_cli_outputs_json():
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.route", "research EU projects"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    data = json.loads(lines[-1])
+    assert data["chosen_agent"] == "research"
+    for field in ["run_id", "prompt_hash", "reason", "ts"]:
+        assert field in data

--- a/tests/test_task_router.py
+++ b/tests/test_task_router.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.task_router import route_task
+
+
+def test_route_task_keyword():
+    agent, reason = route_task("Please research and summarize the topic")
+    assert agent == "research"
+    assert "Matched keywords" in reason
+
+
+def test_route_task_default():
+    agent, reason = route_task("No matching words here")
+    assert agent == "document"
+    assert "default" in reason.lower()


### PR DESCRIPTION
## Summary
- add automatic agent selection via SmartTaskRouter
- expose route_task API and CLI that logs routing decisions
- add tests for router, agent factory auto mode, and CLI

## Testing
- ⚠️ `ruff check .` (fails: F541, F401, etc. in unrelated files)
- ⚠️ `ruff format --check .` (would reformat existing files)
- ⚠️ `pytest -q` (fails: ModuleNotFoundError: No module named 'eufm_assistant')
- ✅ `pytest tests/test_task_router.py tests/test_agent_factory_auto.py tests/test_route_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ded82d94832e8f416f46f28724f0