### PR TITLE
feat(logging): add run_id/task_id + BaseAgent.execute wrapper

### DIFF
--- a/app/agents/coordinator_agent.py
+++ b/app/agents/coordinator_agent.py
@@ -1,10 +1,11 @@
 import yaml
 import re
 from typing import Dict, Any
-from app.agents.base_agent import BaseAgent, AgentStatus
+from app.agents.base_agent import BaseAgent
 from config.settings import get_settings
 
 from app.utils.journal import log_decision
+
 
 class CoordinatorAgent(BaseAgent):
     """An agent responsible for project coordination and status checks."""
@@ -13,7 +14,11 @@ class CoordinatorAgent(BaseAgent):
         super().__init__(agent_id, config)
         self.settings = get_settings()
         self.wbs_file_path = self.settings.app.WBS_DIR / "wbs.yaml"
-        self.proposal_path = self.settings.app.PROJECT_ROOT / "eufm" / "Stage1_Proposal_Cline_Enhanced.md"
+        self.proposal_path = (
+            self.settings.app.PROJECT_ROOT
+            / "eufm"
+            / "Stage1_Proposal_Cline_Enhanced.md"
+        )
         self.wbs = self._load_wbs()
         self.proposal_content = self._load_proposal()
         log_decision("CoordinatorAgent initialized.")
@@ -75,26 +80,10 @@ class CoordinatorAgent(BaseAgent):
         return checklist
 
     def run(self, parameters: Dict[str, Any]) -> Any:
-        """
-        Runs the coordinator agent to perform a specific task.
-        Supported tasks: 'wbs_status', 'proposal_checklist'
-        """
-        self.status = AgentStatus.RUNNING
+        """Runs the coordinator agent to perform a specific task."""
         task = parameters.get("task", "wbs_status")
         self.logger.info(f"Executing task: {task}")
 
-        try:
-            if task == "proposal_checklist":
-                result = self.create_proposal_checklist()
-            else:
-                result = self.determine_next_task()
-            
-            self.result = result
-            self.status = AgentStatus.COMPLETED
-            self.logger.info(f"Task '{task}' completed successfully.")
-            return result
-        except Exception as e:
-            self.error = str(e)
-            self.status = AgentStatus.FAILED
-            self.logger.error(f"Task '{task}' failed: {e}")
-            raise
+        if task == "proposal_checklist":
+            return self.create_proposal_checklist()
+        return self.determine_next_task()

--- a/app/agents/proposal_agent.py
+++ b/app/agents/proposal_agent.py
@@ -1,9 +1,9 @@
-import yaml
 from typing import Dict, Any
 import google.generativeai as genai
-from app.agents.base_agent import BaseAgent, AgentStatus
+from app.agents.base_agent import BaseAgent
 from app.utils.ai_services import AIServices
 from config.settings import get_settings
+
 
 class ProposalAgent(BaseAgent):
     """Agent responsible for generating Horizon Europe proposals."""
@@ -18,27 +18,18 @@ class ProposalAgent(BaseAgent):
     def get_approved_proposal_content(self) -> str:
         """Loads the content of the approved proposal."""
         try:
-            with open(self.settings.app.PROJECT_ROOT / "eufm" / "Stage1_Proposal_Cline_Enhanced.md", "r") as f:
+            with open(
+                self.settings.app.PROJECT_ROOT
+                / "eufm"
+                / "Stage1_Proposal_Cline_Enhanced.md",
+                "r",
+            ) as f:
                 return f.read()
         except FileNotFoundError:
             self.logger.error("Approved proposal file not found.")
             return "Error: Approved proposal file not found."
 
     def run(self, parameters: Dict[str, Any]) -> Any:
-        """
-        Returns the content of the approved Stage 1 proposal.
-        This is a temporary measure to ensure stability for submission.
-        """
-        self.status = AgentStatus.RUNNING
+        """Returns the content of the approved Stage 1 proposal."""
         self.logger.info("Retrieving approved Stage 1 proposal content...")
-        try:
-            result = self.get_approved_proposal_content()
-            self.result = result
-            self.status = AgentStatus.COMPLETED
-            self.logger.info("Successfully retrieved proposal content.")
-            return result
-        except Exception as e:
-            self.error = str(e)
-            self.status = AgentStatus.FAILED
-            self.logger.error(f"Failed to retrieve proposal content: {e}")
-            raise
+        return self.get_approved_proposal_content()

--- a/app/agents/research_agent.py
+++ b/app/agents/research_agent.py
@@ -1,7 +1,8 @@
 import json
 from typing import Dict, Any, List
-from app.agents.base_agent import BaseAgent, AgentStatus
+from app.agents.base_agent import BaseAgent
 from app.utils.ai_services import AIServices
+
 
 class ResearchAgent(BaseAgent):
     """An agent that conducts research by generating and executing a plan."""
@@ -23,7 +24,9 @@ class ResearchAgent(BaseAgent):
         ]
         """
         # For this refactoring, we will use the Perplexity Sonar for this task
-        response_str = self.ai_services.query_perplexity_sonar(prompt, model="sonar-reasoning")
+        response_str = self.ai_services.query_perplexity_sonar(
+            prompt, model="sonar-reasoning"
+        )
         try:
             plan = json.loads(response_str)
             return plan.get("steps", [])
@@ -52,25 +55,12 @@ class ResearchAgent(BaseAgent):
 
     def run(self, parameters: Dict[str, Any]) -> Any:
         """Runs the research agent. Expects 'query' in parameters."""
-        self.status = AgentStatus.RUNNING
         query = parameters.get("query")
         if not query:
-            self.error = "Missing 'query' parameter."
-            self.status = AgentStatus.FAILED
-            self.logger.error(self.error)
-            raise ValueError(self.error)
+            self.logger.error("Missing 'query' parameter.")
+            raise ValueError("Missing 'query' parameter.")
 
         self.logger.info(f"Starting research for query: {query}")
-        try:
-            plan = self.generate_research_plan(query)
-            results = self.execute_research_plan(plan)
-            
-            self.result = results
-            self.status = AgentStatus.COMPLETED
-            self.logger.info(f"Research completed for query: {query}")
-            return results
-        except Exception as e:
-            self.error = str(e)
-            self.status = AgentStatus.FAILED
-            self.logger.error(f"Research failed for query '{query}': {e}")
-            raise
+        plan = self.generate_research_plan(query)
+        results = self.execute_research_plan(plan)
+        return results

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -1,0 +1,24 @@
+import json
+import logging
+from typing import Optional
+
+
+def log_event(
+    run_id: str,
+    task_id: str,
+    agent_id: str,
+    status: str,
+    event: str,
+    error: Optional[str] = None,
+) -> None:
+    """Emit a structured JSON log line for agent events."""
+    record = {
+        "run_id": run_id,
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "status": status,
+        "event": event,
+    }
+    if error:
+        record["error"] = error
+    logging.getLogger("agent").info(json.dumps(record))

--- a/tests/test_execute_logging.py
+++ b/tests/test_execute_logging.py
@@ -1,0 +1,45 @@
+import json
+import logging
+
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.agents.base_agent import BaseAgent, AgentStatus
+
+
+class SuccessAgent(BaseAgent):
+    def run(self, parameters):
+        return "success"
+
+
+class FailingAgent(BaseAgent):
+    def run(self, parameters):
+        raise RuntimeError("failure")
+
+
+def test_execute_success(caplog):
+    agent = SuccessAgent("test", {})
+    with caplog.at_level(logging.INFO, logger="agent"):
+        result = agent.execute({})
+    assert result == "success"
+    assert agent.status == AgentStatus.COMPLETED
+    records = [json.loads(r.message) for r in caplog.records if r.name == "agent"]
+    assert any(rec["event"] == "start" for rec in records)
+    success = next(rec for rec in records if rec["event"] == "success")
+    assert success["run_id"] == agent.run_id
+    assert "task_id" in success
+
+
+def test_execute_failure(caplog):
+    agent = FailingAgent("test", {})
+    with caplog.at_level(logging.INFO, logger="agent"):
+        with pytest.raises(RuntimeError):
+            agent.execute({})
+    assert agent.status == AgentStatus.FAILED
+    records = [json.loads(r.message) for r in caplog.records if r.name == "agent"]
+    failure = next(rec for rec in records if rec["event"] == "failure")
+    assert failure["error"] == "failure"
+    assert failure["status"] == "failed"


### PR DESCRIPTION
## Summary
- add `BaseAgent.execute` to manage lifecycle hooks, status, timestamps and structured logging
- introduce `log_event` helper and run/task IDs for traceable JSON logs
- refactor agents and dashboard to rely on `execute` instead of manual `run`
- add tests for successful and failing execution logging

## Testing
- `ruff check app/agents/base_agent.py app/agents/coordinator_agent.py app/agents/document_agent.py app/agents/research_agent.py app/agents/proposal_agent.py app/dashboard_legacy/app.py app/utils/logging.py tests/test_execute_logging.py`
- `ruff format --check app/agents/base_agent.py app/agents/coordinator_agent.py app/agents/document_agent.py app/agents/research_agent.py app/agents/proposal_agent.py app/dashboard_legacy/app.py app/utils/logging.py tests/test_execute_logging.py`
- `pytest tests/test_execute_logging.py -q`

## Revert Plan
- Revert commit `feat(logging): add execute wrapper with structured logs`

------
https://chatgpt.com/codex/tasks/task_e_68b4e0f6e128832eb5c9ae3c57dae93d