### PR TITLE
feat(exceptions): add and use specific application errors.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,7 @@ def create_app():
     # Register global error handler
     @app.errorhandler(EUFMAssistantException)
     def handle_app_exception(error):
+        app.logger.error(f"{error.__class__.__name__}: {error}")
         response = jsonify(error.to_dict())
         response.status_code = 400  # Or a more specific code
         return response

--- a/app/agents/coordinator_agent.py
+++ b/app/agents/coordinator_agent.py
@@ -5,6 +5,7 @@ from app.agents.base_agent import BaseAgent, AgentStatus
 from config.settings import get_settings
 
 from app.utils.journal import log_decision
+from app.exceptions import AgentExecutionError
 
 class CoordinatorAgent(BaseAgent):
     """An agent responsible for project coordination and status checks."""
@@ -96,5 +97,11 @@ class CoordinatorAgent(BaseAgent):
         except Exception as e:
             self.error = str(e)
             self.status = AgentStatus.FAILED
-            self.logger.error(f"Task '{task}' failed: {e}")
-            raise
+            self.logger.error(
+                f"Task '{task}' failed: {e.__class__.__name__}: {e}"
+            )
+            raise AgentExecutionError(
+                f"Task '{task}' failed",
+                agent_type="coordinator",
+                agent_id=self.agent_id,
+            ) from e

--- a/app/agents/proposal_agent.py
+++ b/app/agents/proposal_agent.py
@@ -1,9 +1,9 @@
-import yaml
 from typing import Dict, Any
 import google.generativeai as genai
 from app.agents.base_agent import BaseAgent, AgentStatus
 from app.utils.ai_services import AIServices
 from config.settings import get_settings
+from app.exceptions import AgentExecutionError
 
 class ProposalAgent(BaseAgent):
     """Agent responsible for generating Horizon Europe proposals."""
@@ -40,5 +40,11 @@ class ProposalAgent(BaseAgent):
         except Exception as e:
             self.error = str(e)
             self.status = AgentStatus.FAILED
-            self.logger.error(f"Failed to retrieve proposal content: {e}")
-            raise
+            self.logger.error(
+                f"Failed to retrieve proposal content: {e.__class__.__name__}: {e}"
+            )
+            raise AgentExecutionError(
+                "Failed to retrieve proposal content",
+                agent_type="proposal",
+                agent_id=self.agent_id,
+            ) from e

--- a/app/agents/research_agent.py
+++ b/app/agents/research_agent.py
@@ -2,6 +2,7 @@ import json
 from typing import Dict, Any, List
 from app.agents.base_agent import BaseAgent, AgentStatus
 from app.utils.ai_services import AIServices
+from app.exceptions import ValidationError, AgentExecutionError
 
 class ResearchAgent(BaseAgent):
     """An agent that conducts research by generating and executing a plan."""
@@ -57,8 +58,8 @@ class ResearchAgent(BaseAgent):
         if not query:
             self.error = "Missing 'query' parameter."
             self.status = AgentStatus.FAILED
-            self.logger.error(self.error)
-            raise ValueError(self.error)
+            self.logger.error(f"{ValidationError.__name__}: {self.error}")
+            raise ValidationError(self.error)
 
         self.logger.info(f"Starting research for query: {query}")
         try:
@@ -72,5 +73,11 @@ class ResearchAgent(BaseAgent):
         except Exception as e:
             self.error = str(e)
             self.status = AgentStatus.FAILED
-            self.logger.error(f"Research failed for query '{query}': {e}")
-            raise
+            self.logger.error(
+                f"Research failed for query '{query}': {e.__class__.__name__}: {e}"
+            )
+            raise AgentExecutionError(
+                f"Research failed for query '{query}'",
+                agent_type="research",
+                agent_id=self.agent_id,
+            ) from e

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -36,3 +36,8 @@ class AgentExecutionError(EUFMAssistantException):
 class ConfigurationError(EUFMAssistantException):
     """Raised when configuration is invalid or missing."""
     pass
+
+
+class ResourceNotFoundError(EUFMAssistantException):
+    """Raised when an expected resource such as a file is missing."""
+    pass

--- a/app/services/agent_factory.py
+++ b/app/services/agent_factory.py
@@ -1,10 +1,14 @@
 from typing import Dict, Any, Type, List
+import logging
 from app.agents.base_agent import BaseAgent
 from app.agents.research_agent import ResearchAgent
 from app.agents.document_agent import DocumentAgent
 from app.agents.proposal_agent import ProposalAgent
 from app.agents.coordinator_agent import CoordinatorAgent
 from app.utils.ai_services import AIServices
+from app.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 class AgentFactory:
     """Factory for creating and configuring AI agents."""
@@ -23,7 +27,10 @@ class AgentFactory:
         """Create an agent instance of the specified type."""
         agent_class = self._agent_registry.get(agent_type)
         if not agent_class:
-            raise ValueError(f"Unknown agent type: {agent_type}")
+            logger.error(
+                f"{ConfigurationError.__name__}: Unknown agent type '{agent_type}'"
+            )
+            raise ConfigurationError(f"Unknown agent type: {agent_type}")
 
         # Combine base config with agent-specific config
         final_config = self.base_config.copy()

--- a/app/tests/test_exceptions.py
+++ b/app/tests/test_exceptions.py
@@ -1,0 +1,50 @@
+import pytest
+
+from app.exceptions import (
+    ConfigurationError,
+    ValidationError,
+    AgentExecutionError,
+    AIServiceError,
+)
+from app.services.agent_factory import AgentFactory
+from app.agents.research_agent import ResearchAgent
+from app.utils.ai_services import AIServices
+from app.utils import ai_services as ai_module
+
+
+def test_agent_factory_unknown_type_raises_configuration_error():
+    factory = AgentFactory(ai_services=AIServices({}), base_config={})
+    with pytest.raises(ConfigurationError):
+        factory.create_agent("unknown", "agent-1")
+
+
+def test_research_agent_missing_query_raises_validation_error():
+    agent = ResearchAgent(agent_id="r1", config={}, ai_services=AIServices({}))
+    with pytest.raises(ValidationError):
+        agent.run({})
+
+
+def test_query_perplexity_sonar_raises_ai_service_error(monkeypatch):
+    services = AIServices({"perplexity_api_key": "key"})
+
+    class DummyClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(*args, **kwargs):
+                    raise RuntimeError("boom")
+
+    monkeypatch.setattr(ai_module, "OpenAI", lambda *args, **kwargs: DummyClient())
+
+    with pytest.raises(AIServiceError):
+        services.query_perplexity_sonar("prompt")
+
+
+def test_research_agent_ai_service_failure_raises_agent_execution_error():
+    class FailingAIServices(AIServices):
+        def query_perplexity_sonar(self, *args, **kwargs):
+            raise AIServiceError("down", service_name="Perplexity Sonar")
+
+    agent = ResearchAgent(agent_id="r1", config={}, ai_services=FailingAIServices({}))
+    with pytest.raises(AgentExecutionError):
+        agent.run({"query": "test"})

--- a/app/utils/ai_services.py
+++ b/app/utils/ai_services.py
@@ -1,8 +1,10 @@
-"""
-This module provides a centralized interface for interacting with various AI services.
-"""
+"""Centralized interface for interacting with various AI services."""
 
+import logging
 from openai import OpenAI
+from app.exceptions import AIServiceError
+
+logger = logging.getLogger(__name__)
 
 class AIServices:
     def __init__(self, settings):
@@ -31,8 +33,11 @@ class AIServices:
         Sends a query to the Perplexity Sonar API and returns the response.
         """
         print(f"--- Querying Perplexity Sonar ({model}) with prompt: {prompt[:50]}... ---")
-        
-        client = OpenAI(api_key=self.settings.get("perplexity_api_key"), base_url="https://api.perplexity.ai")
+
+        client = OpenAI(
+            api_key=self.settings.get("perplexity_api_key"),
+            base_url="https://api.perplexity.ai",
+        )
         
         messages = [
             {"role": "system", "content": "You are an expert research assistant for a Horizon Europe project."},
@@ -45,9 +50,13 @@ class AIServices:
                 messages=messages,
             )
             return response.choices[0].message.content
-        except Exception as e:
-            print(f"--- Error querying Perplexity Sonar: {str(e)} ---")
-            return f"Error: Could not get a response from Perplexity Sonar. Details: {str(e)}"
+        except Exception as e:  # pragma: no cover - network errors not deterministic
+            logger.error(
+                f"Error querying Perplexity Sonar: {e.__class__.__name__}: {e}"
+            )
+            raise AIServiceError(
+                "Could not get a response from Perplexity Sonar", "Perplexity Sonar"
+            ) from e
 
 def get_ai_services(settings):
     """

--- a/app/utils/journal.py
+++ b/app/utils/journal.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 import os
+from app.exceptions import ResourceNotFoundError
 
 # Construct the absolute path to the project root
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -11,10 +12,12 @@ def _read_journal():
     try:
         with open(JOURNAL_FILE, "r") as f:
             return f.read()
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # If the journal doesn't exist, we can start with a template.
         # For this implementation, we'll assume it's created and raise an error.
-        raise FileNotFoundError(f"Journal file not found at {JOURNAL_FILE}")
+        raise ResourceNotFoundError(
+            f"Journal file not found at {JOURNAL_FILE}"
+        ) from exc
 
 def _write_journal(content):
     """Writes content to the journal file."""

--- a/launch_eufm.py
+++ b/launch_eufm.py
@@ -10,7 +10,8 @@ from pathlib import Path
 project_root = Path(__file__).resolve().parent
 sys.path.insert(0, str(project_root))
 
-from app import create_app
+from app import create_app  # noqa: E402
+from app.exceptions import EUFMAssistantException  # noqa: E402
 
 def main():
     """Launch the EUFM Assistant system using the application factory."""
@@ -40,6 +41,8 @@ def main():
         # Run Flask app using the development server
         # For production, a proper WSGI server like Gunicorn should be used.
         app.run(host="0.0.0.0", port=5000, debug=settings.DEBUG if settings else True)
+    except EUFMAssistantException as e:
+        print(f"Application error: {e.__class__.__name__}: {e}")
     except KeyboardInterrupt:
         print("\n\n🛑 EUFM Assistant stopped")
         print("Thank you for using EUFM Assistant!")


### PR DESCRIPTION
## Summary
- extend EUFMAssistant exception hierarchy with `ResourceNotFoundError`
- apply specific errors across agents and services and log exception class and message
- add unit tests for configuration, validation and service failures

## Testing
- `ruff check .` *(fails: F541, F401, E402 etc. in unrelated modules)*
- `ruff format --check .` *(fails: would reformat multiple files)*
- `ruff check app/exceptions.py app/services/agent_factory.py app/utils/journal.py app/utils/ai_services.py app/agents/document_agent.py app/agents/research_agent.py app/agents/coordinator_agent.py app/agents/proposal_agent.py app/__init__.py launch_eufm.py`
- `PYTHONPATH=$PWD pytest app/tests -q`

## Risks
- New exception classes may require updates in downstream integrations relying on old exception types.
- Raising service errors instead of returning strings could surface uncaught errors in existing workflows.

## Revert Plan
- Revert the commit `feat(exceptions): add custom application errors` to restore prior generic exception behavior if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68b4e95f3f8c832e98fa3d13dbd25575