### PR TITLE
feat(research): fetch and parse Horizon Europe Programme Guide

### DIFF
--- a/app/agents/research_agent.py
+++ b/app/agents/research_agent.py
@@ -10,6 +10,10 @@ class ResearchAgent(BaseAgent):
         super().__init__(agent_id, config)
         self.ai_services = ai_services
 
+    def lookup_call_id(self, call_id: str) -> str:
+        """Lookup a call ID in the Horizon Europe Programme Guide."""
+        return self.ai_services.query_programme_guide(call_id)
+
     def generate_research_plan(self, query: str) -> List[Dict[str, str]]:
         """Generates a research plan using an AI model."""
         prompt = f"""

--- a/app/utils/ai_services.py
+++ b/app/utils/ai_services.py
@@ -3,6 +3,8 @@ This module provides a centralized interface for interacting with various AI ser
 """
 
 from openai import OpenAI
+from app.utils.horizon_guide import query_guide
+
 
 class AIServices:
     def __init__(self, settings):
@@ -48,6 +50,10 @@ class AIServices:
         except Exception as e:
             print(f"--- Error querying Perplexity Sonar: {str(e)} ---")
             return f"Error: Could not get a response from Perplexity Sonar. Details: {str(e)}"
+
+    def query_programme_guide(self, topic: str) -> str:
+        """Search the Horizon Europe Programme Guide summary for a topic."""
+        return query_guide(topic)
 
 def get_ai_services(settings):
     """

--- a/app/utils/horizon_guide.py
+++ b/app/utils/horizon_guide.py
@@ -1,0 +1,96 @@
+"""Utilities for fetching and parsing the Horizon Europe Programme Guide."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import requests
+from pypdf import PdfReader
+
+DEFAULT_GUIDE_URL = (
+    "https://ec.europa.eu/info/funding-tenders/opportunities/docs/2021-2027/"
+    "horizon/guidance/programme-guide_horizon_en.pdf"
+)
+DEFAULT_GUIDE_PATH = Path("docs/horizon_europe/Horizon_Europe_Programme_Guide.pdf")
+DEFAULT_SUMMARY_PATH = Path(
+    "docs/horizon_europe/programme_guide_summary.md"
+)
+
+
+def download_programme_guide(
+    url: str = DEFAULT_GUIDE_URL, dest: Path | str = DEFAULT_GUIDE_PATH
+) -> Path | None:
+    """Download the Horizon Europe Programme Guide PDF.
+
+    Attempts to download the guide from ``url`` and save it to ``dest``. If the
+    download fails, ``None`` is returned and the user is expected to manually
+    place the PDF at ``dest``.
+    """
+    dest_path = Path(dest)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        response = requests.get(url, timeout=30)
+        if response.status_code == 200:
+            dest_path.write_bytes(response.content)
+            return dest_path
+        print(
+            "Failed to download programme guide. "
+            f"Status code {response.status_code}. Please download manually "
+            f"and place the PDF at {dest_path}."
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        print(
+            "Error downloading programme guide. "
+            f"Please download manually and place the PDF at {dest_path}. "
+            f"Details: {exc}"
+        )
+    return None
+
+
+def parse_programme_guide(pdf_path: Path | str = DEFAULT_GUIDE_PATH) -> Dict[str, str]:
+    """Parse the programme guide PDF and return key sections.
+
+    The parser is lightweight: it extracts text from the PDF and searches for
+    a few relevant sections such as "Call" requirements and eligibility rules.
+    The returned dictionary maps section titles to extracted text snippets.
+    """
+    path = Path(pdf_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Programme Guide PDF not found at {path}. "
+            "Download it or provide it manually."
+        )
+
+    reader = PdfReader(str(path))
+    full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    sections: Dict[str, str] = {}
+    for title in ["Call", "Eligibility"]:
+        idx = full_text.lower().find(title.lower())
+        if idx != -1:
+            sections[title] = full_text[idx : idx + 500]
+    return sections
+
+
+def create_summary(
+    pdf_path: Path | str = DEFAULT_GUIDE_PATH,
+    output_md: Path | str = DEFAULT_SUMMARY_PATH,
+) -> Path:
+    """Create a Markdown summary from the programme guide."""
+    sections = parse_programme_guide(pdf_path)
+    output = Path(output_md)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# Horizon Europe Programme Guide Summary", ""]
+    for heading, content in sections.items():
+        lines.append(f"## {heading}\n\n{content.strip()}\n")
+    output.write_text("\n".join(lines))
+    return output
+
+
+def query_guide(topic: str, pdf_path: Path | str = DEFAULT_GUIDE_PATH) -> str:
+    """Return the first snippet in the guide that mentions ``topic``."""
+    sections = parse_programme_guide(pdf_path)
+    for content in sections.values():
+        if topic.lower() in content.lower():
+            return content
+    return ""

--- a/app/utils/tests/test_horizon_guide.py
+++ b/app/utils/tests/test_horizon_guide.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from fpdf import FPDF
+
+from app.utils.horizon_guide import (
+    create_summary,
+    download_programme_guide,
+    parse_programme_guide,
+    query_guide,
+)
+
+
+
+def generate_sample_pdf(path: Path) -> Path:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(200, 10, txt="Call ID: HORIZON-423, Eligibility: open to all", ln=True)
+    pdf.output(str(path))
+    return path
+
+def test_download_programme_guide_success(tmp_path, monkeypatch):
+    class DummyResponse:
+        status_code = 200
+        content = b"pdf"
+
+    def dummy_get(url, timeout=30):  # noqa: ARG001
+        return DummyResponse()
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    dest = tmp_path / "guide.pdf"
+    path = download_programme_guide("http://example.com/guide.pdf", dest)
+    assert path == dest
+    assert dest.exists()
+
+def test_download_programme_guide_fallback(tmp_path, monkeypatch, capsys):
+    def dummy_get(url, timeout=30):  # noqa: ARG001
+        raise Exception("network down")
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    dest = tmp_path / "guide.pdf"
+    path = download_programme_guide("http://example.com/guide.pdf", dest)
+    captured = capsys.readouterr()
+    assert path is None
+    assert "Please download manually" in captured.out
+    assert not dest.exists()
+
+def test_parse_and_query(tmp_path):
+    pdf_path = generate_sample_pdf(tmp_path / "sample.pdf")
+    sections = parse_programme_guide(pdf_path)
+    assert "Call" in sections
+    summary_path = tmp_path / "summary.md"
+    create_summary(pdf_path, summary_path)
+    assert summary_path.exists()
+    snippet = query_guide("HORIZON-423", pdf_path)
+    assert "Eligibility" in snippet

--- a/docs/horizon_europe/programme_guide_summary.md
+++ b/docs/horizon_europe/programme_guide_summary.md
@@ -1,0 +1,13 @@
+# Horizon Europe Programme Guide Summary
+
+This summary outlines key sections from the Horizon Europe Programme Guide.
+
+## Call Requirements
+
+- Describes how proposals must align with specific work programme topics.
+- Details submission deadlines and required documentation.
+
+## Eligibility
+
+- Defines eligible participants, including Member States and associated countries.
+- Highlights criteria such as consortium composition and admissibility conditions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ python-json-logger = "*"
 celery = "*"
 redis = "*"
 psycopg2-binary = "*"
+pypdf = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
@@ -37,6 +38,7 @@ isort = "*"
 flake8 = "*"
 mypy = "*"
 pre-commit = "*"
+fpdf = "*"
 ruff = "*"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add utility to download, parse, and query the Horizon Europe Programme Guide
- expose programme guide lookup through AIServices and ResearchAgent
- document summary of key guide sections and add tests for fetching and parsing

## Testing
- `python -m pytest agents/monitor/tests -q` *(fails: file or directory not found)*
- `PYTHONPATH=. python -m pytest app/agents/monitor/tests -q` *(fails: ModuleNotFoundError: eufm_assistant)*
- `python -m pytest app/utils/tests/test_horizon_guide.py -q`
- `python app/agents/monitor/monitor.py --dry-run`
- `ruff check .` *(fails: F541, F401, ...)*
- `ruff format --check .` *(fails: would reformat 24 files)*


------
https://chatgpt.com/codex/tasks/task_e_68b4e9ba3244832e878b476c8ea7b670