### PR TITLE
feat(research): implement Stage 2 research pipeline

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -13,6 +13,16 @@
 - `2025-09-01 00:12:08`: Implemented the failed 'Milestone Archive' task.
 - `2025-09-01 00:12:08`: Merged all successful branches from the overnight initiative into the main branch.
 - `YYYY-MM-DD HH:MM:SS`: Initializing the project journal.
+- `2025-09-02 00:00:00`: Added Stage 2 research pipeline powered by Perplexity Sonar Deep Research.
+
+## Stage 2 Research Pipeline
+Use the Stage2ResearchAgent to create multi-step research plans with citations.
+
+```bash
+python -m app.pipelines.stage2_research_pipeline "<your topic>" --output stage2
+```
+
+The generated `research_plan.json` file will be stored in the specified output directory.
 
 ## Open Questions & Blockers
 - None at this time.

--- a/app/agents/stage2_research_agent.py
+++ b/app/agents/stage2_research_agent.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from app.agents.base_agent import AgentStatus, BaseAgent
+from app.utils.ai_services import AIServices
+
+
+class Stage2ResearchAgent(BaseAgent):
+    """Generates structured research tasks with citations for the Stage 2 proposal."""
+
+    def __init__(self, agent_id: str, config: Dict[str, Any], ai_services: AIServices):
+        super().__init__(agent_id, config)
+        self.ai_services = ai_services
+
+    def _build_prompt(self, query: str) -> str:
+        return (
+            "Generate a multi-step research plan for the following query. "
+            "Return JSON with a 'tasks' list. Each task must include a 'task' field "
+            "and a 'citations' list of objects with 'text' and 'url'. Query: "
+            f"{query}"
+        )
+
+    def _parse_response(self, response: str) -> List[Dict[str, Any]]:
+        try:
+            data = json.loads(response)
+        except (json.JSONDecodeError, TypeError):
+            self.logger.error("Invalid JSON from research model")
+            return []
+        tasks = data.get("tasks")
+        if not isinstance(tasks, list):
+            self.logger.error("Response missing 'tasks' list")
+            return []
+        return tasks
+
+    def generate_tasks(self, query: str) -> List[Dict[str, Any]]:
+        prompt = self._build_prompt(query)
+        response_str = self.ai_services.query("sonar-deep-research", prompt)
+        return self._parse_response(response_str)
+
+    def run(self, parameters: Dict[str, Any]) -> Any:
+        self.status = AgentStatus.RUNNING
+        query = parameters.get("query")
+        if not query:
+            self.status = AgentStatus.FAILED
+            self.error = "Missing 'query' parameter"
+            raise ValueError(self.error)
+        tasks = self.generate_tasks(query)
+        self.result = tasks
+        self.status = AgentStatus.COMPLETED
+        return tasks
+
+
+def save_research_tasks(tasks: List[Dict[str, Any]], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "research_plan.json"
+    with path.open("w", encoding="utf-8") as f:
+        json.dump({"tasks": tasks}, f, indent=2)
+    return path

--- a/app/agents/tests/test_stage2_research_agent.py
+++ b/app/agents/tests/test_stage2_research_agent.py
@@ -1,0 +1,49 @@
+import json
+
+from app.agents.stage2_research_agent import Stage2ResearchAgent, save_research_tasks
+from app.pipelines.stage2_research_pipeline import run_stage2_research_pipeline
+
+
+class DummyAIServices:
+    def __init__(self, response: str):
+        self.response = response
+
+    def query(self, model: str, prompt: str) -> str:
+        assert model == "sonar-deep-research"
+        return self.response
+
+
+def test_agent_parses_and_returns_tasks(tmp_path):
+    response = json.dumps(
+        {
+            "tasks": [
+                {
+                    "task": "Investigate X",
+                    "citations": [{"text": "Source", "url": "https://example.com"}],
+                }
+            ]
+        }
+    )
+    ai_services = DummyAIServices(response)
+    agent = Stage2ResearchAgent("s2", {}, ai_services)
+    tasks = agent.run({"query": "X"})
+    assert tasks[0]["task"] == "Investigate X"
+    path = save_research_tasks(tasks, tmp_path)
+    assert path.exists()
+    saved = json.loads(path.read_text())
+    assert saved["tasks"][0]["citations"][0]["url"] == "https://example.com"
+
+
+def test_pipeline_stores_plan(tmp_path):
+    response = json.dumps({"tasks": [{"task": "A", "citations": []}]})
+    ai_services = DummyAIServices(response)
+    tasks = run_stage2_research_pipeline("query", tmp_path, ai_services)
+    assert tasks[0]["task"] == "A"
+    assert (tmp_path / "research_plan.json").exists()
+
+
+def test_invalid_response_handled_gracefully():
+    ai_services = DummyAIServices("not json")
+    agent = Stage2ResearchAgent("s2", {}, ai_services)
+    tasks = agent.run({"query": "topic"})
+    assert tasks == []

--- a/app/pipelines/__init__.py
+++ b/app/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline modules for project automation."""

--- a/app/pipelines/stage2_research_pipeline.py
+++ b/app/pipelines/stage2_research_pipeline.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from app.agents.stage2_research_agent import Stage2ResearchAgent, save_research_tasks
+from app.utils.ai_services import AIServices, get_ai_services
+
+
+def run_stage2_research_pipeline(
+    query: str,
+    output_dir: Path,
+    ai_services: AIServices,
+    agent_config: Dict[str, Any] | None = None,
+):
+    agent = Stage2ResearchAgent(
+        "stage2-research-agent", agent_config or {}, ai_services
+    )
+    tasks = agent.run({"query": query})
+    save_research_tasks(tasks, output_dir)
+    return tasks
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    import os
+
+    parser = argparse.ArgumentParser(description="Run Stage 2 research pipeline")
+    parser.add_argument("query", help="Research query")
+    parser.add_argument(
+        "--output", default="stage2", help="Directory to store research plan"
+    )
+    args = parser.parse_args()
+
+    settings = {"perplexity_api_key": os.environ.get("PERPLEXITY_API_KEY", "")}
+    ai_services = get_ai_services(settings)
+    output_dir = Path(args.output)
+    tasks = run_stage2_research_pipeline(args.query, output_dir, ai_services)
+    print(json.dumps({"tasks": tasks}, indent=2))

--- a/app/utils/ai_services.py
+++ b/app/utils/ai_services.py
@@ -4,9 +4,16 @@ This module provides a centralized interface for interacting with various AI ser
 
 from openai import OpenAI
 
+
 class AIServices:
     def __init__(self, settings):
         self.settings = settings
+
+    def query(self, model: str, prompt: str) -> str:
+        """Generic interface for querying supported AI models."""
+        if model.startswith("sonar"):
+            return self.query_perplexity_sonar(prompt, model=model)
+        raise ValueError(f"Unsupported model: {model}")
 
     def query_jules_ai(self, prompt):
         """
@@ -22,7 +29,9 @@ class AIServices:
         Sends a query to OpenAI Codex and returns the response.
         (Placeholder implementation)
         """
-        print(f"--- Querying OpenAI Codex for {language} with prompt: {prompt[:50]}... ---")
+        print(
+            f"--- Querying OpenAI Codex for {language} with prompt: {prompt[:50]}... ---"
+        )
         # In a real implementation, this would make an API call to OpenAI Codex.
         return "Generated code from OpenAI Codex."
 
@@ -30,15 +39,23 @@ class AIServices:
         """
         Sends a query to the Perplexity Sonar API and returns the response.
         """
-        print(f"--- Querying Perplexity Sonar ({model}) with prompt: {prompt[:50]}... ---")
-        
-        client = OpenAI(api_key=self.settings.get("perplexity_api_key"), base_url="https://api.perplexity.ai")
-        
+        print(
+            f"--- Querying Perplexity Sonar ({model}) with prompt: {prompt[:50]}... ---"
+        )
+
+        client = OpenAI(
+            api_key=self.settings.get("perplexity_api_key"),
+            base_url="https://api.perplexity.ai",
+        )
+
         messages = [
-            {"role": "system", "content": "You are an expert research assistant for a Horizon Europe project."},
+            {
+                "role": "system",
+                "content": "You are an expert research assistant for a Horizon Europe project.",
+            },
             {"role": "user", "content": prompt},
         ]
-        
+
         try:
             response = client.chat.completions.create(
                 model=model,
@@ -48,6 +65,7 @@ class AIServices:
         except Exception as e:
             print(f"--- Error querying Perplexity Sonar: {str(e)} ---")
             return f"Error: Could not get a response from Perplexity Sonar. Details: {str(e)}"
+
 
 def get_ai_services(settings):
     """


### PR DESCRIPTION
## Summary
- add `AIServices.query` to route model requests
- implement `Stage2ResearchAgent` and supporting pipeline to generate research plans with citations
- document Stage 2 research pipeline and add storage directory

## Testing
- `ruff check . && ruff format --check .` *(fails: F541 etc. in existing code)*
- `python -m pytest app/agents/monitor/tests -q` *(fails: ModuleNotFoundError: eufm_assistant)*
- `python -m pytest app/agents/tests/test_stage2_research_agent.py -q`
- `python app/agents/monitor/monitor.py --dry-run`

## Risks
- pipeline depends on Perplexity API availability and response format
- broader ruff and pytest suites report failures unrelated to new code

## Revert Plan
- `git revert <commit>` to remove Stage 2 research pipeline


------
https://chatgpt.com/codex/tasks/task_e_68b4e9d03ba0832eacd5a78a8cfabe73