### PR TITLE
docs: add system architecture and developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,8 @@ It automates project documentation, partner research, and monitoring so teams ca
 - **Monitoring tools** to track deadlines and project health.
 - **Extensible architecture** built with Python and Flask.
 
-## Architecture Diagram
-```
-eufm/
-├── app/               # Core application package
-│   ├── agents/        # Research, proposal, and monitor agents
-│   ├── api/           # REST API endpoints
-│   ├── models/        # Database models
-│   └── services/      # Business logic
-├── config/            # Configuration files
-├── docs/              # Project documentation
-├── scripts/           # Utility scripts
-└── launch_eufm.py     # Entry point for the web dashboard
-```
+## System Architecture
+See [docs/system_architecture.md](docs/system_architecture.md) for a comprehensive overview of the current architecture and developer guidelines.
 
 ## Getting Started
 1. **Install Poetry** (if not already installed):

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -1,0 +1,79 @@
+# EUFM System Architecture and Developer Guide
+
+This document provides a high-level overview of the EUFM Assistant's architecture and guidance for contributing new components.
+
+## Overview of AI Agents
+
+The EUFM ecosystem coordinates multiple AI agents, each optimized for different tasks:
+
+- **Gemini CLI** – primary command-line agent for executing development and automation tasks.
+- **Claude Code** – assists with code generation and review.
+- **Cline** – orchestration layer that coordinates other agents and system tasks.
+- **Jules** – research-focused agent for knowledge gathering.
+- **OpenAI Codex** – language model used for code completion and generation.
+
+These agents communicate through a shared service layer and follow a common interface defined by `BaseAgent`.
+
+```mermaid
+flowchart LR
+    subgraph Agents
+        GeminiCLI[Gemini CLI]
+        ClaudeCode[Claude Code]
+        Cline
+        Jules
+        Codex[OpenAI Codex]
+    end
+    Agents --> AgentFactory
+    AgentFactory --> BaseAgent
+    BaseAgent --> AIServices
+    AIServices -->|API calls| Providers["Gemini / OpenAI / Perplexity / Jules"]
+```
+
+## Directory Structure
+
+```
+eufm/
+└── app/
+    ├── api/        # REST API endpoints
+    ├── models/     # Data models and schemas
+    ├── services/   # Business logic (AgentFactory, task router)
+    ├── agents/     # Implementations of BaseAgent derivatives
+    └── utils/      # Shared utilities (ai_services, logging helpers)
+```
+
+## Configuration with Pydantic Settings
+
+Configuration is centralized in [`config/settings.py`](../config/settings.py), which uses **Pydantic BaseSettings** to load environment variables and project paths. The `Settings` object exposes application (`app`) and AI service (`ai`) configurations:
+
+```python
+from config.settings import get_settings
+settings = get_settings()
+print(settings.ai.default_model)
+```
+
+## AI Services Abstraction
+
+The [`app/utils/ai_services.py`](../app/utils/ai_services.py) module provides a unified interface for interacting with external AI providers (Gemini, OpenAI Codex, Perplexity Sonar, etc.). All agents depend on this module instead of calling provider SDKs directly, which simplifies provider switching and testing.
+
+## BaseAgent and AgentFactory Pattern
+
+All agents inherit from [`BaseAgent`](../app/agents/base_agent.py), which defines standard lifecycle hooks (`run`, `on_start`, `on_success`, `on_failure`). Agents are instantiated through the [`AgentFactory`](../app/services/agent_factory.py), ensuring consistent configuration and dependency injection (notably `AIServices`).
+
+## Centralized Logging and Error Handling
+
+Each agent and service uses Python's `logging` module, allowing logs to be routed to files or monitoring systems. Custom exceptions in [`app/exceptions.py`](../app/exceptions.py) standardize error reporting across the system, providing structured messages for API consumers and debugging.
+
+## Extending the System
+
+### Adding a New AI Provider
+1. **Update Settings:** Add API keys or configuration options in `config/settings.py`.
+2. **Extend AIServices:** Implement a new method in `app/utils/ai_services.py` that wraps the provider's SDK.
+3. **Use in Agents:** Inject the new service through `AgentFactory` and call it from agent implementations.
+
+### Creating a New Agent
+1. **Subclass `BaseAgent`:** Place the new agent in `app/agents/` and implement the `run` method.
+2. **Register with `AgentFactory`:** Update the registry in `app/services/agent_factory.py` with a key and class reference.
+3. **Leverage AIServices:** Use the centralized `AIServices` instance for provider interactions.
+4. **Handle Errors and Logging:** Utilize the logging framework and raise custom exceptions where appropriate.
+
+Following this pattern keeps the architecture modular and maintainable.


### PR DESCRIPTION
## Summary
- document EUFM architecture, agents, settings, service layer, and extension guidelines
- link README to new architecture guide and drop outdated diagram

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eufm_assistant')*
- `ruff check .` *(fails: F541 f-string without any placeholders and other style errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b4e9ee17f4832e98a0a7ee9e3fa30e