### PR TITLE
feat(cli): unify entrypoints and add help commands

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -13,6 +13,7 @@
 - `2025-09-01 00:12:08`: Implemented the failed 'Milestone Archive' task.
 - `2025-09-01 00:12:08`: Merged all successful branches from the overnight initiative into the main branch.
 - `YYYY-MM-DD HH:MM:SS`: Initializing the project journal.
+- `2025-09-01 00:12:08`: CLI overhaul implementing unified command-line interface.
 
 ## Open Questions & Blockers
 - None at this time.

--- a/README.md
+++ b/README.md
@@ -34,21 +34,21 @@ eufm/
    ```bash
    poetry install
    ```
-3. **Run the application**:
+3. **Run the unified CLI**:
    ```bash
-   poetry run python launch_eufm.py
+   poetry run eufm --help
    ```
 
 ## Usage Examples
-- **Generate a proposal draft**
+- **Route a task to an agent**
   ```bash
-  poetry run python generate_proposal.py
+  poetry run eufm route "Find partners in Italy"
   ```
 - **Run the research agent**
   ```bash
-  poetry run python app/agents/research_agent.py "Find partners in Italy"
+  poetry run eufm research "Find partners in Italy"
   ```
-- **Execute the monitoring system in dry-run mode**
+- **Generate proposal content**
   ```bash
-  poetry run python app/agents/monitor/monitor.py --dry-run
+  poetry run eufm propose
   ```

--- a/app/agents/base_agent.py
+++ b/app/agents/base_agent.py
@@ -47,3 +47,14 @@ class BaseAgent(ABC):
             "result": self.result,
             "error": self.error,
         }
+
+    def execute(self, parameters: Dict[str, Any]) -> Any:
+        """Public method to execute the agent with lifecycle hooks."""
+        try:
+            self.on_start()
+            result = self.run(parameters)
+            self.on_success()
+            return result
+        except Exception as e:
+            self.on_failure(e)
+            raise

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -1,0 +1,109 @@
+import argparse
+import json
+from typing import Any, Dict
+
+from config.settings import get_settings
+from app.services.task_router import route_task
+from app.services.agent_factory import AgentFactory
+from app.utils.ai_services import get_ai_services
+
+
+def _cmd_route(args: argparse.Namespace, **_: Any) -> None:
+    agent = route_task(args.prompt)
+    print(agent)
+
+
+def _cmd_run_agent(
+    args: argparse.Namespace,
+    *,
+    agent_factory: AgentFactory,
+    **_: Any,
+) -> None:
+    params: Dict[str, Any] = json.loads(args.params)
+    agent = agent_factory.create_agent(args.agent, args.id)
+    result = agent.execute(params)
+    print(result)
+
+
+def _cmd_research(
+    args: argparse.Namespace,
+    *,
+    agent_factory: AgentFactory,
+    **_: Any,
+) -> None:
+    agent = agent_factory.create_agent("research", "research-cli")
+    result = agent.execute({"query": args.query})
+    print(result)
+
+
+def _cmd_propose(
+    args: argparse.Namespace,
+    *,
+    agent_factory: AgentFactory,
+    **_: Any,
+) -> None:
+    agent = agent_factory.create_agent("proposal", "proposal-cli")
+    result = agent.execute({})
+    print(result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    epilog = (
+        "Examples:\n"
+        "  eufm route \"find collaborators in Italy\"\n"
+        "  eufm research \"find partners in Spain\"\n"
+        "  eufm run-agent research --params '{\"query\": \"xylella\"}'\n"
+        "  eufm propose\n"
+    )
+    parser = argparse.ArgumentParser(
+        description="Unified command-line interface for EUFM agents.",
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    p_route = subparsers.add_parser("route", help="Suggest an agent for a given task")
+    p_route.add_argument("prompt", help="Task description to route")
+    p_route.set_defaults(func=_cmd_route)
+
+    p_run = subparsers.add_parser("run-agent", help="Execute a specific agent")
+    p_run.add_argument("agent", help="Agent type to run")
+    p_run.add_argument("--id", default="cli", help="Identifier for the agent instance")
+    p_run.add_argument(
+        "--params",
+        default="{}",
+        help="JSON string of parameters to pass to the agent",
+    )
+    p_run.set_defaults(func=_cmd_run_agent)
+
+    p_research = subparsers.add_parser("research", help="Run the research agent")
+    p_research.add_argument("query", help="Research query")
+    p_research.set_defaults(func=_cmd_research)
+
+    p_propose = subparsers.add_parser("propose", help="Generate proposal content")
+    p_propose.set_defaults(func=_cmd_propose)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+
+    settings = get_settings()
+    ai_services = get_ai_services(settings.ai.model_dump())
+    agent_factory = AgentFactory(ai_services=ai_services, base_config={})
+
+    args.func(
+        args,
+        settings=settings,
+        ai_services=ai_services,
+        agent_factory=agent_factory,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/cli/tests/test_cli.py
+++ b/app/cli/tests/test_cli.py
@@ -1,0 +1,38 @@
+import json
+from typing import Dict, Any
+
+import pytest
+
+from app.cli.main import main
+from app.agents.base_agent import BaseAgent
+from app.services.agent_factory import AgentFactory
+
+
+class DummyAgent(BaseAgent):
+    def run(self, parameters: Dict[str, Any]) -> Any:  # type: ignore[override]
+        return {"received": parameters}
+
+
+def dummy_create_agent(self, agent_type: str, agent_id: str, agent_config=None):  # type: ignore[override]
+    return DummyAgent(agent_id, agent_config or {})
+
+
+def test_help_message(capsys):
+    with pytest.raises(SystemExit):
+        main(["--help"])
+    captured = capsys.readouterr()
+    assert "Unified command-line interface" in captured.out
+
+
+def test_route_subcommand(capsys):
+    main(["route", "find collaborators"])
+    captured = capsys.readouterr()
+    assert "Perplexity Sonar" in captured.out
+
+
+def test_run_agent_subcommand(monkeypatch, capsys):
+    monkeypatch.setattr(AgentFactory, "create_agent", dummy_create_agent)
+    params = json.dumps({"query": "test"})
+    main(["run-agent", "research", "--params", params])
+    captured = capsys.readouterr()
+    assert "query" in captured.out

--- a/launch_eufm.py
+++ b/launch_eufm.py
@@ -1,48 +1,7 @@
 #!/usr/bin/env python3
-"""
-EUFM Assistant Launch Script (Refactored)
-"""
-import sys
-from pathlib import Path
+"""Deprecated launch script. Use the unified `eufm` CLI instead."""
+from app.cli.main import main
 
-# Add the project root to the Python path to allow for absolute imports
-# This assumes the launch script is in the 'eufm' directory.
-project_root = Path(__file__).resolve().parent
-sys.path.insert(0, str(project_root))
-
-from app import create_app
-
-def main():
-    """Launch the EUFM Assistant system using the application factory."""
-    print("🔬 EUFM Assistant - European Funds Management System")
-    print("=" * 60)
-    print("🚨 CRITICAL DEADLINE: Stage 1 Proposal Due September 4, 2025")
-    print("=" * 60)
-    
-    app = create_app()
-    
-    # Access settings through the app's config
-    settings = app.config.get('APP')
-    
-    print("\n📋 System Status:")
-    if settings:
-        print(f"✅ Environment: {settings.ENVIRONMENT.value}")
-        print(f"✅ Debug Mode: {settings.DEBUG}")
-    print("✅ AI Services Initialized")
-    
-    print("\n🌐 Starting web interface...")
-    print("📍 URL: http://127.0.0.1:5000")
-    print("\n" + "=" * 60)
-    print("Press Ctrl+C to stop the server")
-    print("=" * 60)
-    
-    try:
-        # Run Flask app using the development server
-        # For production, a proper WSGI server like Gunicorn should be used.
-        app.run(host="0.0.0.0", port=5000, debug=settings.DEBUG if settings else True)
-    except KeyboardInterrupt:
-        print("\n\n🛑 EUFM Assistant stopped")
-        print("Thank you for using EUFM Assistant!")
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ mypy = "*"
 pre-commit = "*"
 ruff = "*"
 
+[tool.poetry.scripts]
+eufm = "app.cli.main:main"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add unified `eufm` CLI with route, run-agent, research, and propose subcommands
- invoke agents via new `BaseAgent.execute` lifecycle wrapper
- deprecate old `launch_eufm.py`, update docs and project journal, and expose CLI via Poetry script

## Testing
- `python -m pytest app/cli/tests -q`
- `python -m pytest agents/monitor/tests -q` *(fails: file or directory not found)*
- `python agents/monitor/monitor.py --dry-run` *(fails: No such file or directory)*
- `ruff check .` *(fails: F541, F401, F811, E402 ...)*
- `ruff format --check .` *(fails: 23 files would be reformatted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eufm_assistant')*

------
https://chatgpt.com/codex/tasks/task_e_68b4ea479594832ead497bf2d365fc70