### PR TITLE
feat: Agent Status Dashboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,23 +3,25 @@ from config.settings import get_settings
 from config.logging import setup_logging
 from app.utils.ai_services import AIServices
 from app.exceptions import EUFMAssistantException
+from app.api.collaboration import bp as collaboration_bp
+
 
 def create_app():
     """Application factory for creating Flask app instances."""
-    
+
     # Initialize logging
     setup_logging()
-    
+
     app = Flask(__name__)
-    
+
     # Load configuration
     settings = get_settings()
-    app.config['APP_SETTINGS'] = settings
-    
+    app.config["APP_SETTINGS"] = settings
+
     # Initialize AI services
     ai_services = AIServices(settings.ai.dict())
     app.ai_services = ai_services
-    
+
     # Register a simple root route for health checks
     @app.route("/")
     def index():
@@ -33,6 +35,9 @@ def create_app():
         response.status_code = 400  # Or a more specific code
         return response
 
+    # Register API blueprints
+    app.register_blueprint(collaboration_bp)
+
     print("Flask App Created and Configured with Logging and Error Handling.")
-    
+
     return app

--- a/app/api/collaboration.py
+++ b/app/api/collaboration.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, jsonify, request
+
+from app.services.status_buffer import get_status_updates
+
+bp = Blueprint("collaboration", __name__, url_prefix="/api/collaboration")
+
+
+@bp.get("/agent_status")
+def agent_status() -> tuple:
+    """Return the most recent agent status updates.
+
+    Query Parameters
+    ----------------
+    limit: int, optional
+        Number of records to return. Defaults to 10.
+    """
+    try:
+        limit = int(request.args.get("limit", 10))
+    except ValueError:
+        limit = 10
+    updates = get_status_updates(limit)
+    return jsonify({"updates": updates}), 200

--- a/app/services/status_buffer.py
+++ b/app/services/status_buffer.py
@@ -1,0 +1,28 @@
+from collections import deque
+from typing import Deque, Dict, List
+
+# Maximum number of status updates to retain in memory.
+_MAX_SIZE = 1000
+
+# Internal ring buffer storing status update dictionaries.
+_status_buffer: Deque[Dict] = deque(maxlen=_MAX_SIZE)
+
+
+def add_status_update(update: Dict) -> None:
+    """Append a new status update to the ring buffer."""
+    _status_buffer.append(update)
+
+
+def get_status_updates(limit: int) -> List[Dict]:
+    """Return the most recent ``limit`` status updates."""
+    if limit <= 0:
+        return []
+    return list(_status_buffer)[-limit:]
+
+
+def clear_status_updates() -> None:
+    """Remove all entries from the ring buffer.
+
+    This is primarily intended for test cleanup.
+    """
+    _status_buffer.clear()

--- a/app/tests/test_agent_status_endpoint.py
+++ b/app/tests/test_agent_status_endpoint.py
@@ -1,0 +1,18 @@
+from app import create_app
+from app.services.status_buffer import add_status_update, clear_status_updates
+
+
+def test_agent_status_endpoint_returns_latest_updates():
+    app = create_app()
+    client = app.test_client()
+
+    clear_status_updates()
+    add_status_update({"agent": "alpha", "status": "Queued", "message": "ready"})
+    add_status_update({"agent": "beta", "status": "Running", "message": "processing"})
+
+    response = client.get("/api/collaboration/agent_status?limit=1")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "updates" in data
+    assert len(data["updates"]) == 1
+    assert data["updates"][0]["agent"] == "beta"

--- a/src/components/AgentStatusDashboard.tsx
+++ b/src/components/AgentStatusDashboard.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+interface AgentStatus {
+  agent: string;
+  message: string;
+  status: 'Queued' | 'Running' | 'Completed' | 'Failed';
+  progress?: number;
+  timestamp?: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+const columns: Record<AgentStatus['status'], string> = {
+  Queued: 'Queued',
+  Running: 'Running',
+  Completed: 'Completed',
+  Failed: 'Failed',
+};
+
+const AgentStatusDashboard: React.FC = () => {
+  const [statuses, setStatuses] = useState<AgentStatus[]>([]);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const resp = await fetch('/api/collaboration/agent_status?limit=50');
+      const data = await resp.json();
+      setStatuses(data.updates || []);
+    } catch (err) {
+      console.error('Failed to fetch agent status history', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${protocol}://${window.location.host}/ws`);
+
+    ws.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        if (payload.event === 'agent_status_update') {
+          setStatuses((prev) => [...prev.slice(-49), payload.data]);
+        }
+      } catch (err) {
+        console.error('Invalid WebSocket message', err);
+      }
+    };
+
+    return () => ws.close();
+  }, []);
+
+  const grouped: Record<string, AgentStatus[]> = statuses.reduce(
+    (acc, item) => {
+      (acc[item.status] ||= []).push(item);
+      return acc;
+    },
+    { Queued: [], Running: [], Completed: [], Failed: [] } as Record<string, AgentStatus[]>
+  );
+
+  return (
+    <div>
+      <button onClick={fetchHistory}>Refresh</button>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        {Object.keys(columns).map((column) => (
+          <div key={column} style={{ flex: 1 }}>
+            <h3>{columns[column as AgentStatus['status']]}</h3>
+            {grouped[column]?.map((item, idx) => (
+              <div
+                key={idx}
+                style={{
+                  border: '1px solid #ccc',
+                  marginBottom: '0.5rem',
+                  padding: '0.5rem',
+                }}
+              >
+                <div><strong>{item.agent}</strong></div>
+                <div>{item.message}</div>
+                {item.progress !== undefined && <div>Progress: {item.progress}%</div>}
+                {item.timestamp && <div>Updated: {new Date(item.timestamp).toLocaleString()}</div>}
+                {item.started_at && <div>Started: {new Date(item.started_at).toLocaleString()}</div>}
+                {item.completed_at && <div>Completed: {new Date(item.completed_at).toLocaleString()}</div>}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AgentStatusDashboard;


### PR DESCRIPTION
## Summary
- expose `GET /api/collaboration/agent_status` returning latest agent status updates from ring buffer
- register collaboration API and create in-memory status buffer service
- add React `AgentStatusDashboard` component with WebSocket updates and refreshable history

## Testing
- `ruff check app/__init__.py app/api/collaboration.py app/services/status_buffer.py app/tests/test_agent_status_endpoint.py`
- `ruff format app/__init__.py app/api/collaboration.py app/services/status_buffer.py app/tests/test_agent_status_endpoint.py --check`
- `python -m pytest app/tests/test_agent_status_endpoint.py -q`
- `python -m pytest app/agents/monitor/tests -q`
- `python app/agents/monitor/monitor.py --dry-run`
- `python -m pytest -q` *(fails: openai.OpenAIError: The api_key client option must be set)*


------
https://chatgpt.com/codex/tasks/task_e_68b5c57fb184832ebe09594a3e6fa661