### PR TITLE
feat: Unified Collaboration Hub

### DIFF
--- a/.state/.gitignore
+++ b/.state/.gitignore
@@ -1,0 +1,1 @@
+chat.jsonl

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,25 +1,41 @@
 from flask import Flask, jsonify
+from flask_socketio import SocketIO
+from pathlib import Path
+
 from config.settings import get_settings
 from config.logging import setup_logging
 from app.utils.ai_services import AIServices
 from app.exceptions import EUFMAssistantException
+from app.services.chat_service import ChatService
+
+socketio = SocketIO()
+
 
 def create_app():
     """Application factory for creating Flask app instances."""
-    
+
     # Initialize logging
     setup_logging()
-    
+
     app = Flask(__name__)
-    
+
     # Load configuration
     settings = get_settings()
-    app.config['APP_SETTINGS'] = settings
-    
+    app.config["APP_SETTINGS"] = settings
+
     # Initialize AI services
     ai_services = AIServices(settings.ai.dict())
     app.ai_services = ai_services
-    
+
+    # Initialize chat service
+    chat_service = ChatService(Path(".state/chat.jsonl"))
+    app.chat_service = chat_service
+
+    # Register API blueprints
+    from app.api import init_app as init_api
+
+    init_api(app)
+
     # Register a simple root route for health checks
     @app.route("/")
     def index():
@@ -33,6 +49,23 @@ def create_app():
         response.status_code = 400  # Or a more specific code
         return response
 
+    socketio.init_app(app, cors_allowed_origins="*")
+
     print("Flask App Created and Configured with Logging and Error Handling.")
-    
+
     return app
+
+
+@socketio.on("message", namespace="/ws")
+def handle_message(data):
+    from flask import current_app
+
+    if not isinstance(data, dict):
+        return
+    user = data.get("user")
+    text = data.get("text")
+    if not user or not text:
+        return
+    msg = {"user": user, "text": text}
+    current_app.chat_service.append(msg)
+    socketio.emit("message", msg, namespace="/ws")

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,7 @@
+from flask import Flask
+
+
+def init_app(app: Flask) -> None:
+    from app.api.collaboration import bp as collaboration_bp
+
+    app.register_blueprint(collaboration_bp)

--- a/app/api/collaboration.py
+++ b/app/api/collaboration.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, Response, current_app, jsonify, request
+
+bp = Blueprint("collaboration", __name__, url_prefix="/api/collaboration")
+
+
+@bp.get("/chat")
+def get_chat() -> Response:
+    limit = request.args.get("limit", default=50, type=int)
+    messages = current_app.chat_service.latest(limit)
+    return jsonify(messages)

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Dict, List
+
+
+class ChatService:
+    """Persist and retrieve chat messages."""
+
+    def __init__(self, path: Path, max_messages: int = 200) -> None:
+        self.path = path
+        self.max_messages = max_messages
+        self._messages: List[Dict[str, str]] = []
+        self._lock = Lock()
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        self._messages.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+            self._messages = self._messages[-self.max_messages :]
+
+    def append(self, message: Dict[str, str]) -> None:
+        with self._lock:
+            self._messages.append(message)
+            self._messages = self._messages[-self.max_messages :]
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(message) + "\n")
+
+    def latest(self, limit: int) -> List[Dict[str, str]]:
+        with self._lock:
+            if limit <= 0:
+                return []
+            return self._messages[-limit:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "app"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 flask = "*"
+flask-socketio = "*"
 openai = "*"
 google-generativeai = "*"
 pyyaml = "*"

--- a/src/components/CollaborationHub.tsx
+++ b/src/components/CollaborationHub.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+interface Message {
+  user: string;
+  text: string;
+}
+
+const CollaborationHub: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [text, setText] = useState('');
+  const socketRef = useRef<Socket | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const user = 'anonymous';
+
+  useEffect(() => {
+    fetch('/api/collaboration/chat?limit=200')
+      .then((res) => res.json())
+      .then((data) => setMessages(data));
+
+    const socket = io('/ws');
+    socketRef.current = socket;
+    socket.on('message', (msg: Message) => {
+      setMessages((prev) => [...prev, msg].slice(-200));
+    });
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = () => {
+    if (!text.trim()) return;
+    socketRef.current?.emit('message', { user, text });
+    setText('');
+  };
+
+  return (
+    <div>
+      <div style={{ height: '300px', overflowY: 'auto', border: '1px solid #ccc', padding: '0.5rem' }}>
+        {messages.map((m, idx) => (
+          <div key={idx}>
+            <strong>{m.user}:</strong> {m.text}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') sendMessage();
+        }}
+      />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  );
+};
+
+export default CollaborationHub;


### PR DESCRIPTION
## Summary
- persist chat messages to disk and serve latest via `/api/collaboration/chat`
- add Socket.IO message broadcasting on `/ws` namespace
- provide React CollaborationHub component for chat UI

## Testing
- `ruff check .` *(fails: redefinition, unused imports, etc.)*
- `ruff format --check .` *(fails: would reformat many files)*
- `ruff check app/__init__.py app/api/collaboration.py app/services/chat_service.py`
- `python -m pytest app/agents/monitor/tests -q`
- `python app/agents/monitor/monitor.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b5c5b47e08832ea0154385d5151f46